### PR TITLE
Update build.yml: remove checkout of 4D Pop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Check out 4D-Pop
-      uses: actions/checkout@v3
-      with:
-        repository: vdelachaux/4DPop
-        path: Components/4DPop.4dbase
     - name: Build
       uses: 4d/build4d-action@main
       


### PR DESCRIPTION
Will use Build folder instead (now supported by action)

J'ai donc mise à jours l'action pour supporter ton dossier Build/Components (en plus de Components/)

Il reste des erreurs sur la variable pop non déclaré (j'ai vu que tu as du cs.pop en commentaire etc..)

--

De plus je log les erreurs de compilation des dépendences, comme 4d pop dépend de 4d svg, on ne pouvait pas le compiler(on ne supporte pas bien les dépendences récursives dans mon action même si il aurait fallu aussi prendre les sources de 4d svg)